### PR TITLE
Update to netty 4.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,12 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.0.29.Final</version>
+                <version>4.0.33.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.0.29.Final</version>
+                <version>4.0.33.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>


### PR DESCRIPTION
See http://netty.io/news/2015/09/30/4-0-32-Final.html
It notably includes `EpollChannelOption.TCP_FASTOPEN` 