### PR TITLE
Upgrade to akka-streams 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - openjdk7
 cache:
   directories:
     - $HOME/.m2

--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -33,7 +33,8 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-stream-experimental_2.11</artifactId>
+            <artifactId>akka-stream_2.11</artifactId>
+            <version>2.4.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,22 +50,22 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.0.33.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.0.33.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
                 <artifactId>reactive-streams</artifactId>
-                <version>1.0.0</version>
+                <version>${reactive-streams.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
                 <artifactId>reactive-streams-tck</artifactId>
-                <version>1.0.0</version>
+                <version>${reactive-streams.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -76,12 +76,18 @@
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
-                <artifactId>akka-stream-experimental_2.11</artifactId>
+                <artifactId>akka-stream_2.11</artifactId>
                 <version>1.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <properties>
+        <netty.version>4.0.34.Final</netty.version>
+        <reactive-streams.version>1.0.0</reactive-streams.version>
+        <akka-stream.version>2.4.2</akka-stream.version>
+    </properties>
 
     <build>
       <plugins>
@@ -127,7 +133,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>2.4</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -153,7 +159,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Also, upgrade netty to version 4.0.34.Final.

Most of the migration was done following [the guide](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.3/java/migration-guide-1.0-2.x-java.html).

This is somewhat related to playframework/playframework#5878. After this PR was reviewed and merged, we can refactor the code to  throws an `IllegalStateException` when `netty-reactive-streams` gets the duplicate `onComplete`, [as suggested](https://github.com/playframework/playframework/pull/5878#issuecomment-196657600) by @jroper.