### PR TITLE
Fixes a Bug inside the ServerHandler

### DIFF
--- a/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/HttpStreamsTest.java
+++ b/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/HttpStreamsTest.java
@@ -114,6 +114,20 @@ public class HttpStreamsTest {
     }
 
     @Test
+    public void noContentLength204Response() throws Exception {
+        responseServer(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT,
+                Unpooled.EMPTY_BUFFER));
+        client.writeAndFlush(helper.createStreamedRequest("GET", "/", Collections.<String>emptyList()));
+        FullHttpResponse response = receiveFullResponse();
+
+        assertFalse(HttpHeaders.isContentLengthSet(response));
+        assertEquals(helper.extractBody(response), "");
+
+        client.closeFuture().await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        assertTrue(client.isOpen());
+    }
+
+    @Test
     public void cancelRequestBody() throws Exception {
         createEchoServer();
         start(new AutoReadHandler() {


### PR DESCRIPTION
It was assumed that all responses should define a Content-Length or a Transfer-Encoding, this assumption is wrong since 1xx, 204 and 304 don't need these.

Actually this fixes: https://github.com/playframework/playframework/issues/5821