### PR TITLE
fixes gzip with http content decompressor

### DIFF
--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-stream_2.11</artifactId>
-            <version>2.4.2</version>
+            <version>${akka-stream.version}</version>
         </dependency>
     </dependencies>
 

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsServerHandler.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsServerHandler.java
@@ -64,9 +64,10 @@ public class HttpStreamsServerHandler extends HttpStreamsHandler<HttpRequest, Ht
 
     @Override
     protected boolean hasBody(HttpRequest request) {
-        // Http requests don't have a body if they define 0 content length, or no content length and no transfer
-        // encoding
-        return HttpHeaders.getContentLength(request, 0) != 0 || HttpHeaders.isTransferEncodingChunked(request);
+        // Http requests don't have a body if they define 0 content length and no transfer encoding
+        // If they define neither a content length and a transfer encoding it could be a gzip request
+        return HttpHeaders.getContentLength(request, 0) != 0 == HttpHeaders.isContentLengthSet(request) ||
+                HttpHeaders.isTransferEncodingChunked(request);
     }
 
     @Override

--- a/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/HttpStreamsTest.java
+++ b/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/HttpStreamsTest.java
@@ -74,19 +74,6 @@ public class HttpStreamsTest {
     }
 
     @Test
-    public void emptyRequestResponse() throws Exception {
-        createEchoServer();
-        client.writeAndFlush(helper.createStreamedRequest("POST", "/", Collections.<String>emptyList()));
-        FullHttpResponse response = receiveFullResponse();
-
-        helper.assertRequestTypeFull(response);
-        assertFalse(helper.hasRequestContentLength(response));
-
-        assertEquals(helper.extractBody(response), "");
-        assertEquals(HttpHeaders.getContentLength(response), 0);
-    }
-
-    @Test
     public void zeroLengthRequestResponse() throws Exception {
         createEchoServer();
         client.writeAndFlush(helper.createStreamedRequest("POST", "/", Collections.<String>emptyList(), 0));


### PR DESCRIPTION
This should Fix: https://github.com/playframework/playframework/issues/6152

@jroper WDYT? Actually this has the downside that a malicious client could actually send empty Http Requests that will be sent to a Stream even without any content, this could actually make the processing upstream a little bit slower when many empty messages are sent, do you think that is a problem?

But actually I tought about that a while and I think the only other way to fix that would change the HttpContentDecompressor on netty and either re add the Content-Length header there or add a Transfer-Encoding header there, but I'm not sure if they would do that.

There is a comment in the code here:
```
// Remove content-length header:
// the correct value can be set only after all chunks are processed/decoded.
// If buffering is not an issue, add HttpObjectAggregator down the chain, it will set the header.
// Otherwise, rely on LastHttpContent message.
```
But actually HttpObjectAggregator will also change every Transfer-Encoding: chunked request, too.